### PR TITLE
Add in-memory travel plan management

### DIFF
--- a/src/main/java/com/sigma/travelplans/domain/service/TravelPlanService.java
+++ b/src/main/java/com/sigma/travelplans/domain/service/TravelPlanService.java
@@ -1,0 +1,25 @@
+package com.sigma.travelplans.domain.service;
+
+import com.sigma.travelplans.domain.TravelPlan;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+
+public class TravelPlanService {
+
+    private final Map<String, TravelPlan> travelPlans = new HashMap<>();
+
+    public void add(TravelPlan travelPlan) {
+        if (travelPlans.containsKey(travelPlan.getName())) {
+            throw new IllegalArgumentException(
+                    "No pueden haber dos planes con el mismo nombre"
+            );
+        }
+        travelPlans.put(travelPlan.getName(), travelPlan);
+    }
+
+    public Collection<TravelPlan> findAll() {
+        return travelPlans.values();
+    }
+}


### PR DESCRIPTION
Implements an in-memory service to store and manage travel plans.

Ensures unique plan names and provides access to stored plans.
No persistence or web-related logic included.

Closes #5 