### PR TITLE
Add business rules validation to travel plan domain

### DIFF
--- a/src/main/java/com/sigma/travelplans/domain/service/TravelPlanService.java
+++ b/src/main/java/com/sigma/travelplans/domain/service/TravelPlanService.java
@@ -1,5 +1,6 @@
 package com.sigma.travelplans.domain.service;
 
+import com.sigma.travelplans.domain.PlanType;
 import com.sigma.travelplans.domain.TravelPlan;
 
 import java.util.Collection;
@@ -11,12 +12,43 @@ public class TravelPlanService {
     private final Map<String, TravelPlan> travelPlans = new HashMap<>();
 
     public void add(TravelPlan travelPlan) {
+        validate(travelPlan);
+
         if (travelPlans.containsKey(travelPlan.getName())) {
             throw new IllegalArgumentException(
                     "No pueden haber dos planes con el mismo nombre"
             );
         }
+
         travelPlans.put(travelPlan.getName(), travelPlan);
+    }
+
+    private void validate(TravelPlan travelPlan) {
+        if (travelPlan == null) {
+            throw new IllegalArgumentException("EL plan no puede ser nulo");
+        }
+
+        if (isBlank(travelPlan.getName())
+                || travelPlan.getType() == null
+                || isBlank(travelPlan.getOriginCity())
+                || isBlank(travelPlan.getDestinationCity())) {
+            throw new IllegalArgumentException("Todos los campos son obligatorios");
+        }
+
+        if (travelPlan.getAdultSeats() < 0 || travelPlan.getChildSeats() < 0) {
+            throw new IllegalArgumentException("Los asientos deben ser cero o un número positivo");
+        }
+
+        if (travelPlan.getType() == PlanType.WORK
+                && travelPlan.getChildSeats() > 0) {
+            throw new IllegalArgumentException(
+                    "Los planes de trabajo no pueden tener asientos para niños"
+            );
+        }
+    }
+
+    private boolean isBlank(String value) {
+        return value == null || value.trim().isEmpty();
     }
 
     public Collection<TravelPlan> findAll() {


### PR DESCRIPTION
Implements the business rules defined in the technical test.

Validation is handled in the domain service and remains independent
from the web layer.

Closes #7 