### PR TITLE
Allow deletion of travel plans

### DIFF
--- a/src/main/java/com/sigma/travelplans/domain/service/TravelPlanService.java
+++ b/src/main/java/com/sigma/travelplans/domain/service/TravelPlanService.java
@@ -54,4 +54,16 @@ public class TravelPlanService {
     public Collection<TravelPlan> findAll() {
         return travelPlans.values();
     }
+
+    public void remove(String name) {
+        if (isBlank(name)) {
+            throw new IllegalArgumentException("El nombre del plan es obligatorio");
+        }
+
+        if (!travelPlans.containsKey(name)) {
+            throw new IllegalArgumentException("El plan no existe");
+        }
+
+        travelPlans.remove(name);
+    }
 }

--- a/src/main/java/com/sigma/travelplans/web/TravelPlanServlet.java
+++ b/src/main/java/com/sigma/travelplans/web/TravelPlanServlet.java
@@ -37,6 +37,15 @@ public class TravelPlanServlet extends HttpServlet {
             HttpServletResponse response
     ) throws ServletException, IOException {
 
+        String action = request.getParameter("action");
+
+        if ("delete".equals(action)) {
+            String name = request.getParameter("name");
+            travelPlanService.remove(name);
+            response.sendRedirect(request.getContextPath() + "/travel-plans");
+            return;
+        }
+
         try {
             String name = request.getParameter("name");
             String typeParam = request.getParameter("type");

--- a/src/main/webapp/list.jsp
+++ b/src/main/webapp/list.jsp
@@ -15,6 +15,7 @@
         <th>Destino</th>
         <th>Adultos</th>
         <th>Niños</th>
+        <th>Acciones</th>
     </tr>
 <%
     Collection<TravelPlan> plans =
@@ -30,6 +31,13 @@
         <td><%= plan.getDestinationCity() %></td>
         <td><%= plan.getAdultSeats() %></td>
         <td><%= plan.getChildSeats() %></td>
+        <td>
+            <form method="post" action="<%= request.getContextPath() %>/travel-plans">
+                <input type="hidden" name="action" value="delete"/>
+                <input type="hidden" name="name" value="<%= plan.getName() %>"/>
+                <button type="submit">Eliminar</button>
+            </form>
+        </td>
     </tr>
 <%
         }


### PR DESCRIPTION
This PR adds the ability to delete existing travel plans from the list view.

Included:

Delete action triggered from the plans table
In-memory removal via the service layer
Redirect back to the list after deletion

Closes #15 